### PR TITLE
Update Version 1.1.7.6

### DIFF
--- a/source/includes/changelog.md
+++ b/source/includes/changelog.md
@@ -7,6 +7,7 @@ Update Client Released: v1.1.7.6
 
 - 전체적인 소스 코드 리팩토링
 - `models.py` 내부 클래스들의 Docstring 파라미터 타입 수정
+- 약간의 성능 개선
 
 ### 2021-02-26
 Update Client Released: v1.1.7.5


### PR DESCRIPTION
Update Version 1.1.7.6

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Update Version 1.1.7.6